### PR TITLE
Do not run scheduled jobs immediately

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -254,7 +254,7 @@ func runSchedule(s *gocron.Scheduler, schedule string, jobFun interface{}) {
 
 	arr := strings.Split(schedule, " ")
 	if len(arr) == 1 {
-		s.Every(schedule).Do(jobFun)
+		s.Every(schedule).WaitForSchedule().Do(jobFun)
 	} else {
 		s.Cron(schedule).Do(jobFun)
 	}


### PR DESCRIPTION
prevent scheduled jobs from running immediately, (only for Every() call, as Cron jobs should no start immediately by default)