### PR TITLE
Add support for HTTPS Prometheus in DISCOVERY_PROMETHEUS_NAMES

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -364,7 +364,11 @@ func Execute() {
 				m := make(map[string]string)
 				m["name"] = prom.Name
 				m["url"] = prom.URL
-				opts.URL = common.Render(discoveryPrometheusOptions.URL, m, observability)
+				if strings.HasPrefix(strings.ToLower(prom.URL), "https://") {
+					opts.URL = prom.URL
+				} else {
+					opts.URL = common.Render(discoveryPrometheusOptions.URL, m, observability)
+				}
 				opts.HttpUsername = prom.HttpUsername
 				opts.HttpPassword = prom.HttpPassword
 


### PR DESCRIPTION
Just added the edge case of "https" without reworking any logic here. Everything is open for discussion.

**How does this originally work:**
Originally, in line #367, we have this code: 
`opts.URL = common.Render(discoveryPrometheusOptions.URL, m, observability)`
That piece of code grabs the default `DISCOVERY_PROMETHEUS_URL` variable, which is `http://{{.url}}` for all clusters, and replaces `{{.url}}` with the current Prometheus discovery object's URL.
So, for example, if we're currently processing `gtc-prometheus.kube-prometheus.svc:9090`, then `opts.URL` will have a value of `http://gtc-prometheus.kube-prometheus.svc:9090`.

This is a problem if we want to define a Prometheus host with HTTPS: 
If we define a Prometheus host with HTTPS in any cluster's `patch.yml` file, for example:
```
- name: DISCOVERY_PROMETHEUS_NAMES
  value: "trading=https://prometheus-trading.trading-monitoring.svc"
```
This wouldn't work, because the `DISCOVERY_PROMETHEUS_URL` variable is `http://{{.url}}` for all clusters, and the result of the `common.Render()` function in line #367 would end up something like `http://https://prometheus-trading.trading-monitoring.svc`

**Current changes:**
With the changes I propose here, the line `opts.URL = common.Render(discoveryPrometheusOptions.URL, m, observability)` is only called for normal scenarios where HTTPS is NOT defined.
If one of us defines a Prometheus host with HTTPS, then the raw URL that we define will be taken into account and assigned to `opts.URL` without being processed by `common.Render()`, because such processing is not needed when this scheme is defined.
So, looking at the example above, `opts.URL` will directly take the value `https://prometheus-trading.trading-monitoring.svc` without further steps.