### PR TITLE
SRE-4592: Discover k8s images

### DIFF
--- a/sink/observability.go
+++ b/sink/observability.go
@@ -87,6 +87,17 @@ func (o *Observability) Process(d common.Discovery, so common.SinkObject) {
 			}
 		}
 
+	case "K8s":
+		lm = make(map[string]common.Labels)
+		for k, v := range m {
+			ks, ok := v.(common.SinkMap)
+			if ok {
+				for s, i := range ks {
+					lm[s] = common.MergeLabels(i.(common.Labels), common.Labels{"kind": k})
+				}
+			}
+		}
+
 	default:
 		lm = common.ConvertSyncMapToLabelsMap(m)
 	}


### PR DESCRIPTION
k8s discovery discovers two types of objects - workload and image observability sink support both and add kind label with object type pubsub sink process only workload object