### PR TITLE
SRE-5776: Implement cache for rendered templates

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -353,8 +353,8 @@ var sinkWebServerOptions = sink.WebServerOptions{
 	Cert:       envGet("SINK_WEBSERVER_CERT", "").(string),
 	Key:        envGet("SINK_WEBSERVER_KEY", "").(string),
 	Chain:      envGet("SINK_WEBSERVER_CHAIN", "").(string),
-
-	Providers: strings.Split(envStringExpand("SINK_WEBSERVER_PROVIDERS", ""), ","),
+	Providers:  strings.Split(envStringExpand("SINK_WEBSERVER_PROVIDERS", ""), ","),
+	RenderTTL:  time.Duration(envGet("SINK_WEBSERVER_RENDER_TTL", 5).(int)),
 }
 
 func getOnlyEnv(key string) string {
@@ -502,9 +502,7 @@ func Execute() {
 			sinks.Add(sink.NewTelegraf(sinkTelegrafOptions, obs))
 			sinks.Add(sink.NewObservability(sinkObservabilityOptions, obs))
 			sinks.Add(sink.NewPubSub(sinkPubSubOptions, obs))
-
-			ws := sink.NewWebServer(sinkWebServerOptions, obs)
-			if ws != nil {
+			if ws := sink.NewWebServer(sinkWebServerOptions, obs); ws != nil {
 				sinks.Add(ws)
 				ws.Start(&mainWG)
 			}

--- a/common/sink.go
+++ b/common/sink.go
@@ -67,7 +67,9 @@ func AppendHostSink(m SinkMap, name string, hs HostSink) {
 }
 
 func (ss *Sinks) Add(s Sink) {
-	ss.list = append(ss.list, s)
+	if s != nil {
+		ss.list = append(ss.list, s)
+	}
 }
 
 func (ss *Sinks) Process(d Discovery, so SinkObject) {

--- a/common/utils.go
+++ b/common/utils.go
@@ -111,23 +111,21 @@ func FileMd5ToString(path string) string {
 }
 
 func IfDef(v, def interface{}) interface{} {
-
 	if utils.IsEmpty(v) {
 		return def
 	}
-	switch v.(type) {
+	switch v := v.(type) {
 	case string:
-		if v.(string) == "" {
+		if v == "" {
 			return def
 		}
 	case int:
-		if v.(int) == 0 {
+		if v == 0 {
 			return def
 		}
 	}
 	return v
 }
-
 func StringInArr(a string, arr []string) bool {
 	for _, b := range arr {
 		if b == a {


### PR DESCRIPTION
- do not render templates on HEAD requests
- handle HEAD request for /files/ endpoint
- return Method Not Allowed on unsupported methods
- sanitize file path
- code cleanup