### PR TITLE
Add generation of randomized collection offset

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -265,6 +265,7 @@ var sinkTelegrafOptions = sink.TelegrafOptions{
 		PersistMetrics: envGet("SINK_TELEGRAF_SIGNAL_PERSIST_METRICS", false).(bool),
 		Exclusion:      envStringExpand("SINK_TELEGRAF_SIGNAL_EXCLUSION", ""),
 		InputPrometheusHttpOptions: telegraf.InputPrometheusHttpOptions{
+			CollectionOffset: envGet("SINK_TELEGRAF_SIGNAL_OFFSET", "0s").(string),
 			Interval:         envGet("SINK_TELEGRAF_SIGNAL_INTERVAL", "10s").(string),
 			Version:          envGet("SINK_TELEGRAF_SIGNAL_VERSION", "v1").(string),
 			Params:           envGet("SINK_TELEGRAF_SIGNAL_PARAMS", "").(string),

--- a/telegraf/common.go
+++ b/telegraf/common.go
@@ -291,6 +291,11 @@ func randomizeOffsetDuration(durationStr string) (string, error) {
 		return "0s", fmt.Errorf("Duration value cannot be negative: %d", maxValue)
 	}
 
+	// skip rest
+	if maxValue == 0 {
+		return "0s", nil
+	}
+
 	// Create a new random number generator with a unique seed
 	source := rand.NewSource(time.Now().UnixNano())
 	r := rand.New(source)

--- a/telegraf/prometheus_http.go
+++ b/telegraf/prometheus_http.go
@@ -33,26 +33,28 @@ type InputPrometheusHttpAvailability struct {
 }
 
 type InputPrometheusHttp struct {
-	Name          string                             `toml:"name"`
-	URL           string                             `toml:"url"`
-	User          string                             `toml:"user,omitempty"`
-	Password      string                             `toml:"password,omitempty"`
-	Version       string                             `toml:"version"`
-	Params        string                             `toml:"params,omitempty"`
-	Interval      string                             `toml:"interval"`
-	Timeout       string                             `toml:"timeout"`
-	Duration      string                             `toml:"duration,omitempty"`
-	Prefix        string                             `toml:"prefix"`
-	File          []*InputPrometheusHttpFile         `toml:"file"`
-	Metric        []*InputPrometheusHttpMetric       `toml:"metric"`
-	Availability  []*InputPrometheusHttpAvailability `toml:"metric"`
-	Tags          map[string]string                  `toml:"tags,omitempty"`
-	Include       []string                           `toml:"taginclude,omitempty"`
-	SkipEmptyTags bool                               `toml:"skip_empty_tags"`
-	observability *common.Observability
+	Name             string                             `toml:"name"`
+	URL              string                             `toml:"url"`
+	User             string                             `toml:"user,omitempty"`
+	Password         string                             `toml:"password,omitempty"`
+	Version          string                             `toml:"version"`
+	Params           string                             `toml:"params,omitempty"`
+	CollectionOffset string                             `toml:"collection_offset"`
+	Interval         string                             `toml:"interval"`
+	Timeout          string                             `toml:"timeout"`
+	Duration         string                             `toml:"duration,omitempty"`
+	Prefix           string                             `toml:"prefix"`
+	File             []*InputPrometheusHttpFile         `toml:"file"`
+	Metric           []*InputPrometheusHttpMetric       `toml:"metric"`
+	Availability     []*InputPrometheusHttpAvailability `toml:"metric"`
+	Tags             map[string]string                  `toml:"tags,omitempty"`
+	Include          []string                           `toml:"taginclude,omitempty"`
+	SkipEmptyTags    bool                               `toml:"skip_empty_tags"`
+	observability    *common.Observability
 }
 
 type InputPrometheusHttpOptions struct {
+	CollectionOffset string
 	Interval         string
 	URL              string
 	User             string


### PR DESCRIPTION
The idea is to generate a number of configuration files with preset (but random for each file) collection offsets.

The offset, as per Telegraf documentation, should work on each period. e.g. if collection interval is 10s, then collection would execute at 00:00:00, 00:00:10, 00:00:20, etc. With offset of 3s it should be like 00:00:03, 00:00:13, 00:00:23, etc

We already have collection jitter parameter, but its not always the best option, especially if aggregators are present.

With aggregator interval, say, of 15s, having interval + jitter (10s + 5s) values exceeding that interval may lead to undesired fluctuations in metrics values, because values would be getting in to different aggregator intervals. With preset offset it should be stable.